### PR TITLE
Avoid duplicates when storing and unstoring

### DIFF
--- a/utils/nfw_main.cfg
+++ b/utils/nfw_main.cfg
@@ -26,6 +26,9 @@
     [filter]
         [not]
             id=$nfw_exclude_unit_id
+            [or]
+                find_in=nfw_wounded
+            [/or]
         [/not]
     [/filter]
 
@@ -72,16 +75,31 @@ This does not apply to any unit that the objectives require you to keep alive. E
 # In multiplayer the victory event is synchronized since 1.13.10
 [event]
     name=victory
+    id=nfw_victory_unstore
+    [store_unit]
+        [filter]
+        [/filter]
+        variable=nfw_alive_units
+    [/store_unit]
     [foreach]
         array=nfw_wounded
         [do]
-            {VARIABLE this_item.hitpoints $this_item.max_hitpoints}
-            {VARIABLE this_item.status.poisoned "no"}
-            {VARIABLE this_item.status.slowed "no"}
-            [unstore_unit]
-                variable=this_item
-                x,y=recall,recall
-            [/unstore_unit]
+            [if]
+                [have_unit]
+                    id=$this_item.id
+                    find_in=nfw_alive_units
+                    search_recall_list=yes
+                [/have_unit]
+                [else]
+                    {VARIABLE this_item.hitpoints $this_item.max_hitpoints}
+                    {VARIABLE this_item.status.poisoned "no"}
+                    {VARIABLE this_item.status.slowed "no"}
+                    [unstore_unit]
+                        variable=this_item
+                        x,y=recall,recall
+                    [/unstore_unit]
+                [/else]
+            [/if]
         [/do]
     [/foreach]
     {CLEAR_VARIABLE nfw_wounded}


### PR DESCRIPTION
What do you think about this? It's the safest way I've thought of. It first checks that it is not already in nfw_wounded to avoid duplicates, in case some scenario invokes the same unit id repeatedly.
And then, when doing unstore on the victory event, it is checked that the saved unit was not brought back to life by other methods before the victory event, to avoid conflicts with special events of some scenarios.
This resolves #3 and other potential conflicts.